### PR TITLE
Add commands for managing leaderboards

### DIFF
--- a/commands.go
+++ b/commands.go
@@ -6,13 +6,16 @@ import (
 
 	"github.com/bwmarrin/discordgo"
 	"github.com/itizir/hrv/countvotes"
+	"github.com/itizir/hrv/leaderboard"
 )
 
 type Handler func(s *discordgo.Session, i *discordgo.InteractionCreate) error
 
 var (
 	commands = map[*discordgo.ApplicationCommand]Handler{
-		countvotes.ApplicationCommand: countvotes.Handle,
+		countvotes.ApplicationCommand:       countvotes.Handle,
+		leaderboard.ApplicationCommand:      leaderboard.Handle,
+		leaderboard.ApplicationAdminCommand: leaderboard.HandleAdmin,
 	}
 
 	commandHandlers map[string]Handler
@@ -34,6 +37,8 @@ func interactionHandle(s *discordgo.Session, i *discordgo.InteractionCreate) {
 	case discordgo.InteractionMessageComponent:
 		spl := strings.SplitN(i.MessageComponentData().CustomID, ":", 2)
 		name = spl[0]
+	case discordgo.InteractionModalSubmit:
+		name = i.ModalSubmitData().CustomID
 	}
 
 	if h, ok := commandHandlers[name]; ok {

--- a/go.mod
+++ b/go.mod
@@ -5,6 +5,7 @@ go 1.22
 require (
 	cloud.google.com/go/secretmanager v1.13.0
 	github.com/bwmarrin/discordgo v0.28.1
+	golang.org/x/text v0.14.0
 )
 
 require (
@@ -32,7 +33,6 @@ require (
 	golang.org/x/oauth2 v0.19.0 // indirect
 	golang.org/x/sync v0.7.0 // indirect
 	golang.org/x/sys v0.19.0 // indirect
-	golang.org/x/text v0.14.0 // indirect
 	golang.org/x/time v0.5.0 // indirect
 	google.golang.org/api v0.177.0 // indirect
 	google.golang.org/genproto v0.0.0-20240401170217-c3f982113cda // indirect

--- a/leaderboard/admin.go
+++ b/leaderboard/admin.go
@@ -1,6 +1,7 @@
 package leaderboard
 
 import (
+	"errors"
 	"fmt"
 	"log"
 	"os"
@@ -69,7 +70,7 @@ const (
 
 func HandleAdmin(s *discordgo.Session, i *discordgo.InteractionCreate) error {
 	// for now insist it can only me me. better solution would be role-based enforced in Guild settings instead of done here in the handler
-	if i.Member == nil || (i.Member.User.ID != AdminID && !slices.Contains(i.Member.Roles, "")) {
+	if i.Member == nil || i.Member.User.ID != AdminID {
 		return s.InteractionRespond(i.Interaction,
 			&discordgo.InteractionResponse{
 				Type: discordgo.InteractionResponseChannelMessageWithSource,
@@ -135,7 +136,7 @@ func optionsToDict(opts []*discordgo.ApplicationCommandInteractionDataOption) ma
 
 func deleteEntry(s *discordgo.Session, i *discordgo.InteractionCreate, name string, rank, season int) error {
 	if name == "" && rank < 1 {
-		return fmt.Errorf("need at least name or rank")
+		return errors.New("need at least name or rank")
 	}
 
 	thread, _, err := getSeasonThread(s, i.GuildID, i.AppID, season)
@@ -150,9 +151,10 @@ func deleteEntry(s *discordgo.Session, i *discordgo.InteractionCreate, name stri
 	}
 
 	match := func(s string) bool {
-		i := strings.Index(s, "\\. ")
+		sep := "\\. "
+		i := strings.Index(s, sep)
 		if i > 0 {
-			s = s[i+3:]
+			s = s[i+len(sep):]
 		}
 		return strings.HasPrefix(s, name)
 	}

--- a/leaderboard/admin.go
+++ b/leaderboard/admin.go
@@ -3,10 +3,7 @@ package leaderboard
 import (
 	"errors"
 	"fmt"
-	"log"
 	"os"
-	"slices"
-	"strings"
 
 	"github.com/bwmarrin/discordgo"
 )
@@ -90,11 +87,11 @@ func HandleAdmin(s *discordgo.Session, i *discordgo.InteractionCreate) error {
 	switch o.Name {
 	case adminCommandDelete:
 		vals := optionsToDict(o.Options)
-		name, _ := vals[adminCommandArgKeyName].(string)
-		if name != "" {
-			id, err := findUserID(s, i.GuildID, name)
+		nameOrMention, _ := vals[adminCommandArgKeyName].(string)
+		if nameOrMention != "" {
+			id, err := findUserID(s, i.GuildID, nameOrMention)
 			if err == nil && id != "" {
-				name = userMention(id)
+				nameOrMention = userMention(id)
 			}
 		}
 		rank, _ := vals[adminCommandArgKeyRank].(float64)
@@ -102,7 +99,7 @@ func HandleAdmin(s *discordgo.Session, i *discordgo.InteractionCreate) error {
 		if !ok {
 			season = -1
 		}
-		if err := deleteEntry(s, i, name, int(rank), int(season)); err != nil {
+		if err := deleteEntry(s, i, nameOrMention, int(rank), int(season)); err != nil {
 			msg = err.Error()
 		} else {
 			msg = "OK!"
@@ -135,8 +132,8 @@ func optionsToDict(opts []*discordgo.ApplicationCommandInteractionDataOption) ma
 	return vals
 }
 
-func deleteEntry(s *discordgo.Session, i *discordgo.InteractionCreate, name string, rank, season int) error {
-	if name == "" && rank < 1 {
+func deleteEntry(s *discordgo.Session, i *discordgo.InteractionCreate, nameOrMention string, rank, season int) error {
+	if nameOrMention == "" && rank < 1 {
 		return errors.New("need at least name or rank")
 	}
 
@@ -145,58 +142,12 @@ func deleteEntry(s *discordgo.Session, i *discordgo.InteractionCreate, name stri
 		return err
 	}
 
-	msg, err := s.ChannelMessage(thread.ID, thread.ID)
+	ld, err := getLeaderboardData(s, thread)
 	if err != nil {
-		log.Printf("failed to fetch message %v: %v", thread.ID, err)
-		return errors.New("failed to fetch message")
+		return err
 	}
 
-	blockNumber := 0
-	match := func(s string) bool {
-		if s == "" {
-			blockNumber++
-			return false
-		}
-		switch blockNumber {
-		case 0:
-			sep := "\\. "
-			i := strings.Index(s, sep)
-			if i > 0 {
-				s = s[i+len(sep):]
-			}
-			return strings.HasPrefix(s, name)
-		case 1:
-			return strings.HasPrefix(s, unorderedPrefix+name)
-		default:
-			return false
-		}
-	}
-	if rank > 0 {
-		m := fmt.Sprintf("%d\\. %s", rank, name)
-		match = func(s string) bool {
-			if blockNumber > 0 {
-				return false
-			}
-			if s == "" {
-				blockNumber++
-				return false
-			}
-			return strings.HasPrefix(s, m)
-		}
-	}
+	ld.removeEntries(nameOrMention, rank)
 
-	entries := strings.Split(msg.Content, "\n")
-	update := slices.DeleteFunc(entries, match)
-	content := strings.Join(update, "\n")
-	// clean up if laste unordered entry was deleted
-	content = strings.Replace(content, unorderedHeader+"\n\n", "", 1)
-	content = strings.TrimSuffix(content, "\n\n"+unorderedHeader)
-
-	_, err = s.ChannelMessageEdit(thread.ID, thread.ID, content)
-	if err != nil {
-		log.Printf("failed to edit leaderboard %v: %v", thread.ID, err)
-		return errors.New("failed to edit leaderboard message")
-	}
-
-	return nil
+	return ld.updateMessages(s)
 }

--- a/leaderboard/admin.go
+++ b/leaderboard/admin.go
@@ -142,6 +142,11 @@ func deleteEntry(s *discordgo.Session, i *discordgo.InteractionCreate, nameOrMen
 		return err
 	}
 
+	if !yuckyMutex.TryLock() {
+		return fmt.Errorf("%s is currently busy, sorry; try again", userMention(i.AppID))
+	}
+	defer yuckyMutex.Unlock()
+
 	ld, err := getLeaderboardData(s, thread)
 	if err != nil {
 		return err

--- a/leaderboard/admin.go
+++ b/leaderboard/admin.go
@@ -68,7 +68,7 @@ const (
 )
 
 func HandleAdmin(s *discordgo.Session, i *discordgo.InteractionCreate) error {
-	// for now insist it can only me me. better solution would be role-based enfored in Guild settings instead of done here in the handler
+	// for now insist it can only me me. better solution would be role-based enforced in Guild settings instead of done here in the handler
 	if i.Member == nil || (i.Member.User.ID != AdminID && !slices.Contains(i.Member.Roles, "")) {
 		return s.InteractionRespond(i.Interaction,
 			&discordgo.InteractionResponse{

--- a/leaderboard/admin.go
+++ b/leaderboard/admin.go
@@ -69,7 +69,7 @@ const (
 )
 
 func HandleAdmin(s *discordgo.Session, i *discordgo.InteractionCreate) error {
-	// for now insist it can only me me. better solution would be role-based enforced in Guild settings instead of done here in the handler
+	// for now insist it can only be me. better solution would be role-based enforced in Guild settings instead of done here in the handler
 	if i.Member == nil || i.Member.User.ID != AdminID {
 		return s.InteractionRespond(i.Interaction,
 			&discordgo.InteractionResponse{

--- a/leaderboard/admin.go
+++ b/leaderboard/admin.go
@@ -1,0 +1,176 @@
+package leaderboard
+
+import (
+	"fmt"
+	"log"
+	"os"
+	"slices"
+	"strings"
+
+	"github.com/bwmarrin/discordgo"
+)
+
+var (
+	ApplicationAdminCommand = &discordgo.ApplicationCommand{
+		Type:        discordgo.ChatApplicationCommand,
+		Name:        "rank_admin",
+		Description: "Admin functions for leaderboard",
+		Options: []*discordgo.ApplicationCommandOption{
+			{
+				Type:        discordgo.ApplicationCommandOptionSubCommand,
+				Name:        adminCommandDelete,
+				Description: "Remove a player rank entry from leaderboard",
+				Options: []*discordgo.ApplicationCommandOption{
+					{
+						Type:        discordgo.ApplicationCommandOptionString,
+						Name:        adminCommandArgKeyName,
+						Description: "Player name (prefix-matching)",
+					},
+					{
+						Type:        discordgo.ApplicationCommandOptionInteger,
+						Name:        adminCommandArgKeyRank,
+						Description: "Player rank",
+					},
+					{
+						Type:        discordgo.ApplicationCommandOptionInteger,
+						Name:        adminCommandArgKeySeason,
+						Description: "Season number, defaults to latest",
+					},
+				},
+			},
+			{
+				Type:        discordgo.ApplicationCommandOptionSubCommand,
+				Name:        adminCommandStartSeason,
+				Description: "Start a new season",
+				Options: []*discordgo.ApplicationCommandOption{
+					{
+						Type:        discordgo.ApplicationCommandOptionString,
+						Name:        adminCommandArgKeyName,
+						Description: fmt.Sprintf("Season name, needs to start with %q", threadNamePrefix),
+						Required:    true,
+					},
+				},
+			},
+		},
+	}
+
+	// export for easy override in testing environment
+	AdminID = os.Getenv("LEADERBOARD_ADMIN_ID")
+)
+
+const (
+	adminCommandDelete      = "delete"
+	adminCommandStartSeason = "start"
+
+	adminCommandArgKeyName   = "name"
+	adminCommandArgKeyRank   = "rank"
+	adminCommandArgKeySeason = "season"
+)
+
+func HandleAdmin(s *discordgo.Session, i *discordgo.InteractionCreate) error {
+	// for now insist it can only me me. better solution would be role-based enfored in Guild settings instead of done here in the handler
+	if i.Member == nil || (i.Member.User.ID != AdminID && !slices.Contains(i.Member.Roles, "")) {
+		return s.InteractionRespond(i.Interaction,
+			&discordgo.InteractionResponse{
+				Type: discordgo.InteractionResponseChannelMessageWithSource,
+				Data: &discordgo.InteractionResponseData{
+					Content: fmt.Sprintf("Unauthorised. Ask %s for help!", userMention(AdminID)),
+					Flags:   discordgo.MessageFlagsEphemeral,
+				},
+			})
+	}
+
+	if l := len(i.ApplicationCommandData().Options); l != 1 {
+		return fmt.Errorf("invalid options length in %s: %d", ApplicationAdminCommand.Name, l)
+	}
+	o := i.ApplicationCommandData().Options[0]
+
+	msg := "Not yet implemented!"
+	switch o.Name {
+	case adminCommandDelete:
+		vals := optionsToDict(o.Options)
+		name, _ := vals[adminCommandArgKeyName].(string)
+		if name != "" {
+			mem, err := s.GuildMembersSearch(i.GuildID, name, 2)
+			if err == nil && len(mem) == 1 {
+				name = userMention(mem[0].User.ID)
+			}
+		}
+		rank, _ := vals[adminCommandArgKeyRank].(float64)
+		season, ok := vals[adminCommandArgKeySeason].(float64)
+		if !ok {
+			season = -1
+		}
+		if err := deleteEntry(s, i, name, int(rank), int(season)); err != nil {
+			msg = err.Error()
+		} else {
+			msg = "OK!"
+		}
+	case adminCommandStartSeason:
+		vals := optionsToDict(o.Options)
+		name, _ := vals[adminCommandArgKeyName].(string)
+		if err := createSeasonThread(s, i.GuildID, name); err != nil {
+			return err
+		}
+		msg = "OK!"
+	}
+
+	return s.InteractionRespond(i.Interaction,
+		&discordgo.InteractionResponse{
+			Type: discordgo.InteractionResponseChannelMessageWithSource,
+			Data: &discordgo.InteractionResponseData{
+				Content: msg,
+				Flags:   discordgo.MessageFlagsEphemeral,
+			},
+		})
+}
+
+func optionsToDict(opts []*discordgo.ApplicationCommandInteractionDataOption) map[string]any {
+	vals := make(map[string]any)
+	for _, o := range opts {
+		vals[o.Name] = o.Value
+	}
+	return vals
+}
+
+func deleteEntry(s *discordgo.Session, i *discordgo.InteractionCreate, name string, rank, season int) error {
+	if name == "" && rank < 1 {
+		return fmt.Errorf("need at least name or rank")
+	}
+
+	thread, _, err := getSeasonThread(s, i.GuildID, i.AppID, season)
+	if err != nil {
+		return err
+	}
+
+	msg, err := s.ChannelMessage(thread.ID, thread.ID)
+	if err != nil {
+		log.Printf("failed to fetch message %v: %v", thread.ID, err)
+		return fmt.Errorf("failed to fetch message")
+	}
+
+	match := func(s string) bool {
+		i := strings.Index(s, "\\. ")
+		if i > 0 {
+			s = s[i+3:]
+		}
+		return strings.HasPrefix(s, name)
+	}
+	if rank > 0 {
+		m := fmt.Sprintf("%d\\. %s", rank, name)
+		match = func(s string) bool {
+			return strings.HasPrefix(s, m)
+		}
+	}
+
+	entries := strings.Split(msg.Content, "\n")
+	update := slices.DeleteFunc(entries, match)
+
+	_, err = s.ChannelMessageEdit(thread.ID, thread.ID, strings.Join(update, "\n"))
+	if err != nil {
+		log.Printf("failed to edit leaderboard %v: %v", thread.ID, err)
+		return fmt.Errorf("failed to edit leaderboard message")
+	}
+
+	return nil
+}

--- a/leaderboard/command.go
+++ b/leaderboard/command.go
@@ -1,0 +1,54 @@
+package leaderboard
+
+import (
+	"fmt"
+
+	"github.com/bwmarrin/discordgo"
+)
+
+var (
+	ApplicationCommand = &discordgo.ApplicationCommand{
+		Type:        discordgo.ChatApplicationCommand,
+		Name:        "rank",
+		Description: "Report player rank for leaderboard",
+	}
+)
+
+func Handle(s *discordgo.Session, i *discordgo.InteractionCreate) error {
+	msg := ""
+	switch i.Type {
+	case discordgo.InteractionApplicationCommand:
+		if err := presentModal(s, i); err != nil {
+			msg = err.Error()
+		}
+	case discordgo.InteractionModalSubmit:
+		if id, err := editLeaderboard(s, i); err != nil {
+			msg = fmt.Sprintf("Failed to edit leaderboard: %v.", err)
+		} else {
+			msg = fmt.Sprintf("Leaderboard %s successfully edited.", channelMention(id))
+		}
+	default:
+		return fmt.Errorf("unhandled interaction type: %v", i.Type)
+	}
+
+	if msg != "" {
+		return s.InteractionRespond(i.Interaction,
+			&discordgo.InteractionResponse{
+				Type: discordgo.InteractionResponseChannelMessageWithSource,
+				Data: &discordgo.InteractionResponseData{
+					Content: msg,
+					Flags:   discordgo.MessageFlagsEphemeral,
+				},
+			})
+	}
+
+	return nil
+}
+
+func userMention(id string) string {
+	return (&discordgo.User{ID: id}).Mention()
+}
+
+func channelMention(id string) string {
+	return (&discordgo.Channel{ID: id}).Mention()
+}

--- a/leaderboard/command.go
+++ b/leaderboard/command.go
@@ -2,6 +2,7 @@ package leaderboard
 
 import (
 	"fmt"
+	"sync"
 
 	"github.com/bwmarrin/discordgo"
 )
@@ -12,6 +13,10 @@ var (
 		Name:        "rank",
 		Description: "Report player rank for leaderboard",
 	}
+
+	// the fetch messages-update messages operation is very much non-atomic, so races could be bad
+	// don't want to go overboard trying to synchronise more elegantly...
+	yuckyMutex sync.Mutex
 )
 
 func Handle(s *discordgo.Session, i *discordgo.InteractionCreate) error {

--- a/leaderboard/leaderboard.go
+++ b/leaderboard/leaderboard.go
@@ -1,8 +1,10 @@
 package leaderboard
 
 import (
+	"errors"
 	"fmt"
 	"log"
+	"slices"
 	"strings"
 
 	"github.com/bwmarrin/discordgo"
@@ -21,18 +23,29 @@ const (
 	modalKeyRankPoints = "rank_points"
 	modalKeyPlayer     = "player"
 	modalKeySeason     = "season"
+
+	unorderedHeader = "Master-level players of unknown rank:"
+	unorderedPrefix = "- "
 )
 
 func Handle(s *discordgo.Session, i *discordgo.InteractionCreate) error {
+	msg := ""
 	switch i.Type {
 	case discordgo.InteractionApplicationCommand:
-		return presentModal(s, i)
-	case discordgo.InteractionModalSubmit:
-		msg := "Leaderboard successfully edited."
-		err := editLeaderboard(s, i)
-		if err != nil {
-			msg = fmt.Sprintf("Failed to edit leaderboard: %v.", err)
+		if err := presentModal(s, i); err != nil {
+			msg = err.Error()
 		}
+	case discordgo.InteractionModalSubmit:
+		if err := editLeaderboard(s, i); err != nil {
+			msg = fmt.Sprintf("Failed to edit leaderboard: %v.", err)
+		} else {
+			msg = "Leaderboard successfully edited."
+		}
+	default:
+		return fmt.Errorf("unhandled interaction type: %v", i.Type)
+	}
+
+	if msg != "" {
 		return s.InteractionRespond(i.Interaction,
 			&discordgo.InteractionResponse{
 				Type: discordgo.InteractionResponseChannelMessageWithSource,
@@ -42,7 +55,8 @@ func Handle(s *discordgo.Session, i *discordgo.InteractionCreate) error {
 				},
 			})
 	}
-	return fmt.Errorf("unhandled interaction type: %v", i.Type)
+
+	return nil
 }
 
 func editLeaderboard(s *discordgo.Session, i *discordgo.InteractionCreate) error {
@@ -58,10 +72,17 @@ func editLeaderboard(s *discordgo.Session, i *discordgo.InteractionCreate) error
 	msg, err := s.ChannelMessage(thread.ID, thread.ID)
 	if err != nil {
 		log.Printf("failed to fetch message %v: %v", thread.ID, err)
-		return fmt.Errorf("failed to fetch message")
+		return errors.New("failed to fetch message")
 	}
 
-	entries := strings.Split(msg.Content, "\n")
+	blocks := strings.Split(msg.Content, "\n\n")
+	if len(blocks) == 0 {
+		return errors.New("empty post")
+	}
+
+	rankUnknown := ent.rank == 0
+
+	entries := strings.Split(blocks[0], "\n")
 	var (
 		added  bool
 		update []string
@@ -69,22 +90,61 @@ func editLeaderboard(s *discordgo.Session, i *discordgo.InteractionCreate) error
 	for _, e := range entries {
 		r, n, isID := getRankAndName(e)
 		if (isID && n == ent.userID) || n == ent.name {
+			if rankUnknown {
+				return errors.New("player already ranked")
+			}
 			continue
 		}
-		if !added && r >= ent.rank {
+		if !rankUnknown && !added && (r >= ent.rank) {
 			update = append(update, ent.String())
 			added = true
 		}
 		update = append(update, e)
 	}
-	if !added {
+	if !rankUnknown && !added {
 		update = append(update, ent.String())
+		added = true
+	}
+	if added {
+		blocks[0] = strings.Join(update, "\n")
 	}
 
-	_, err = s.ChannelMessageEdit(thread.ID, thread.ID, strings.Join(update, "\n"))
+	var unorderedEntries []string
+	if len(blocks) > 1 && strings.HasPrefix(blocks[1], unorderedHeader) {
+		unorderedEntries = strings.Split(blocks[1], "\n")
+	} else if rankUnknown {
+		unorderedEntries = []string{unorderedHeader}
+	}
+	ent.rank = 0
+	newEntry := unorderedPrefix + ent.String()
+	if added {
+		unorderedEntries = slices.DeleteFunc(unorderedEntries, func(e string) bool { return e == newEntry })
+	} else {
+		if slices.Contains(unorderedEntries, newEntry) {
+			return errors.New("player already reported as master")
+		}
+		unorderedEntries = append(unorderedEntries, newEntry)
+	}
+	if l := len(unorderedEntries); l == 1 {
+		blocks = slices.Delete(blocks, 1, 2)
+	} else if l > 1 {
+		slices.Sort(unorderedEntries[1:])
+		unorderedBlock := strings.Join(unorderedEntries, "\n")
+		if len(blocks) == 1 {
+			blocks = append(blocks, unorderedBlock)
+		} else {
+			if !strings.HasPrefix(blocks[1], unorderedHeader) {
+				blocks = append(blocks, "")
+				copy(blocks[2:], blocks[1:])
+			}
+			blocks[1] = unorderedBlock
+		}
+	}
+
+	_, err = s.ChannelMessageEdit(thread.ID, thread.ID, strings.Join(blocks, "\n\n"))
 	if err != nil {
 		log.Printf("failed to edit leaderboard %v: %v", thread.ID, err)
-		return fmt.Errorf("failed to edit leaderboard message")
+		return errors.New("failed to edit leaderboard message")
 	}
 
 	return nil

--- a/leaderboard/leaderboard.go
+++ b/leaderboard/leaderboard.go
@@ -14,7 +14,7 @@ import (
 const (
 	unorderedPrefix = "- "
 
-	discordMessageLimit = 2000
+	discordMessageCharacterLimit = 2000
 )
 
 // returns the ID of the leaderboard channel
@@ -119,7 +119,7 @@ func getLeaderboardData(s *discordgo.Session, thread *discordgo.Channel) (leader
 
 func (ld leaderboardData) updateMessages(s *discordgo.Session) error {
 	currentMessageIndex := 0
-	currentPageContent := leaderboardMessagePrefix + "\n"
+	currentPageContent := leaderboardMessagePrefix
 
 	postPage := func() error {
 		if currentMessageIndex >= len(ld.msgs) {
@@ -139,12 +139,12 @@ func (ld leaderboardData) updateMessages(s *discordgo.Session) error {
 	printLines := func(lines []string) error {
 		for _, l := range lines {
 			// +1 to account for the newline separator
-			if len(currentPageContent)+len(l)+1 > discordMessageLimit {
+			if len(currentPageContent)+len(l)+1 > discordMessageCharacterLimit {
 				if err := postPage(); err != nil {
 					return err
 				}
 			} else {
-				// avoid newline if it's the start of a page
+				// avoid newline if it's the start of a page. for the very first line there should be a header in place already, so newline is fine
 				currentPageContent += "\n"
 			}
 			currentPageContent += l
@@ -162,7 +162,7 @@ func (ld leaderboardData) updateMessages(s *discordgo.Session) error {
 	}
 
 	if len(ld.unordered) > 0 {
-		currentPageContent = unknownRankMessagePrefix + "\n"
+		currentPageContent = unknownRankMessagePrefix
 
 		// ironic... :P
 		slices.Sort(ld.unordered)

--- a/leaderboard/leaderboard.go
+++ b/leaderboard/leaderboard.go
@@ -29,6 +29,11 @@ func editLeaderboard(s *discordgo.Session, i *discordgo.InteractionCreate) (stri
 		return "", err
 	}
 
+	if !yuckyMutex.TryLock() {
+		return "", fmt.Errorf("%s is currently busy, sorry; try again", userMention(i.AppID))
+	}
+	defer yuckyMutex.Unlock()
+
 	ld, err := getLeaderboardData(s, thread)
 	if err != nil {
 		log.Printf("failed to fetch leaderboard data from channel %v: %v", thread.ID, err)

--- a/leaderboard/leaderboard.go
+++ b/leaderboard/leaderboard.go
@@ -67,7 +67,7 @@ func editLeaderboard(s *discordgo.Session, i *discordgo.InteractionCreate) error
 		update []string
 	)
 	for _, e := range entries {
-		r, n, isID := partialParsing(e)
+		r, n, isID := getRankAndName(e)
 		if (isID && n == ent.userID) || n == ent.name {
 			continue
 		}

--- a/leaderboard/leaderboard.go
+++ b/leaderboard/leaderboard.go
@@ -1,0 +1,91 @@
+package leaderboard
+
+import (
+	"fmt"
+	"log"
+	"strings"
+
+	"github.com/bwmarrin/discordgo"
+)
+
+var (
+	ApplicationCommand = &discordgo.ApplicationCommand{
+		Type:        discordgo.ChatApplicationCommand,
+		Name:        "rank",
+		Description: "Report player rank for leaderboard",
+	}
+)
+
+const (
+	modalKeyRank       = "rank"
+	modalKeyRankPoints = "rank_points"
+	modalKeyPlayer     = "player"
+	modalKeySeason     = "season"
+)
+
+func Handle(s *discordgo.Session, i *discordgo.InteractionCreate) error {
+	switch i.Type {
+	case discordgo.InteractionApplicationCommand:
+		return presentModal(s, i)
+	case discordgo.InteractionModalSubmit:
+		msg := "Leaderboard successfully edited."
+		err := editLeaderboard(s, i)
+		if err != nil {
+			msg = fmt.Sprintf("Failed to edit leaderboard: %v.", err)
+		}
+		return s.InteractionRespond(i.Interaction,
+			&discordgo.InteractionResponse{
+				Type: discordgo.InteractionResponseChannelMessageWithSource,
+				Data: &discordgo.InteractionResponseData{
+					Content: msg,
+					Flags:   discordgo.MessageFlagsEphemeral,
+				},
+			})
+	}
+	return fmt.Errorf("unhandled interaction type: %v", i.Type)
+}
+
+func editLeaderboard(s *discordgo.Session, i *discordgo.InteractionCreate) error {
+	ent, season, err := parseModalInput(s, i)
+	if err != nil {
+		return err
+	}
+
+	thread, _, err := getSeasonThread(s, i.GuildID, i.AppID, season)
+	if err != nil {
+		return err
+	}
+	msg, err := s.ChannelMessage(thread.ID, thread.ID)
+	if err != nil {
+		log.Printf("failed to fetch message %v: %v", thread.ID, err)
+		return fmt.Errorf("failed to fetch message")
+	}
+
+	entries := strings.Split(msg.Content, "\n")
+	var (
+		added  bool
+		update []string
+	)
+	for _, e := range entries {
+		r, n, isID := partialParsing(e)
+		if (isID && n == ent.userID) || n == ent.name {
+			continue
+		}
+		if !added && r >= ent.rank {
+			update = append(update, ent.String())
+			added = true
+		}
+		update = append(update, e)
+	}
+	if !added {
+		update = append(update, ent.String())
+	}
+
+	_, err = s.ChannelMessageEdit(thread.ID, thread.ID, strings.Join(update, "\n"))
+	if err != nil {
+		log.Printf("failed to edit leaderboard %v: %v", thread.ID, err)
+		return fmt.Errorf("failed to edit leaderboard message")
+	}
+
+	return nil
+}

--- a/leaderboard/modal.go
+++ b/leaderboard/modal.go
@@ -129,7 +129,7 @@ func parseModalInput(s *discordgo.Session, i *discordgo.InteractionCreate) (ent 
 			ent.userID = mem[0].User.ID
 		} else {
 			// don't go crazy with sanitisation, but don't allow callers to pollute with unexpected line breaks
-			ent.name = strings.ReplaceAll(v, "\n", "")
+			ent.name = strings.ReplaceAll(v, "\n", " ")
 		}
 	}
 

--- a/leaderboard/modal.go
+++ b/leaderboard/modal.go
@@ -1,0 +1,151 @@
+package leaderboard
+
+import (
+	"fmt"
+	"log"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/bwmarrin/discordgo"
+)
+
+func presentModal(s *discordgo.Session, i *discordgo.InteractionCreate) error {
+	_, currentSeason, err := getSeasonThread(s, i.GuildID, i.AppID, -1)
+	if err != nil {
+		return err
+	}
+
+	return s.InteractionRespond(i.Interaction, &discordgo.InteractionResponse{
+		Type: discordgo.InteractionResponseModal,
+		Data: &discordgo.InteractionResponseData{
+			Title:    "Update Player Rank",
+			CustomID: ApplicationCommand.Name,
+			Components: []discordgo.MessageComponent{
+				discordgo.ActionsRow{Components: []discordgo.MessageComponent{
+					discordgo.TextInput{
+						Label:       "Rank",
+						Style:       discordgo.TextInputShort,
+						Placeholder: "Leaderboard position held",
+						CustomID:    modalKeyRank,
+						MinLength:   1,
+						MaxLength:   6,
+					},
+				}},
+				discordgo.ActionsRow{Components: []discordgo.MessageComponent{
+					discordgo.TextInput{
+						Label:       "Rank points",
+						Style:       discordgo.TextInputShort,
+						Placeholder: "Optional. prefix ~ if approx, suffix ? if guess",
+						CustomID:    modalKeyRankPoints,
+						Required:    false,
+						MaxLength:   10,
+					},
+				}},
+				discordgo.ActionsRow{Components: []discordgo.MessageComponent{
+					discordgo.TextInput{Label: "Player",
+						Style:       discordgo.TextInputShort,
+						Placeholder: "Leave empty if reporting own rank",
+						CustomID:    modalKeyPlayer,
+						Required:    false,
+						MaxLength:   80,
+					},
+				}},
+				discordgo.ActionsRow{Components: []discordgo.MessageComponent{
+					discordgo.TextInput{Label: "Season",
+						Style:       discordgo.TextInputShort,
+						Placeholder: "Season number",
+						Value:       strconv.Itoa(currentSeason),
+						CustomID:    modalKeySeason,
+						Required:    false,
+						MaxLength:   2,
+					},
+				}},
+			},
+		},
+	})
+}
+
+func modalDataToDict(cmps []discordgo.MessageComponent) (map[string]string, error) {
+	data := make(map[string]string, len(cmps))
+	for _, cmp := range cmps {
+		row, ok := cmp.(*discordgo.ActionsRow)
+		if !ok {
+			return nil, fmt.Errorf("unexpected modal data type: (%T) %v", cmp, cmp)
+		}
+		if len(row.Components) != 1 {
+			return nil, fmt.Errorf("unexpected modal row length: %v", len(row.Components))
+		}
+		input, ok := row.Components[0].(*discordgo.TextInput)
+		if !ok {
+			return nil, fmt.Errorf("unexpected modal data type in row: (%T) %v", cmp, cmp)
+		}
+		data[input.CustomID] = input.Value
+	}
+	return data, nil
+}
+
+func parseModalInput(s *discordgo.Session, i *discordgo.InteractionCreate) (ent entry, season int, err error) {
+	data, err := modalDataToDict(i.ModalSubmitData().Components)
+	if err != nil {
+		return ent, 0, err
+	}
+
+	u, err := strconv.ParseUint(data[modalKeyRank], 10, 32)
+	if err != nil || u == 0 {
+		return ent, 0, fmt.Errorf("invalid rank value")
+	}
+	ent.rank = int(u)
+
+	if v := data[modalKeyRankPoints]; v != "" {
+		if l := len(v); l > 0 && v[l-1] == '?' {
+			ent.guess = true
+			v = v[:l-1]
+		}
+		if len(v) > 0 && v[0] == '~' {
+			ent.approx = true
+			v = v[1:]
+		}
+		u, err = strconv.ParseUint(v, 10, 32)
+		if err != nil {
+			return ent, 0, fmt.Errorf("invalid rank points value")
+		}
+		ent.points = int(u)
+	}
+
+	if i.Member == nil {
+		return ent, 0, fmt.Errorf("command should be used within discord guild")
+	}
+	if v := data[modalKeyPlayer]; v == "" {
+		ent.userID = i.Member.User.ID
+	} else {
+		mem, err := s.GuildMembersSearch(i.GuildID, v, 2)
+		if err != nil {
+			log.Println("failed to look up user:", err)
+			return ent, 0, fmt.Errorf("failed to look up user")
+		}
+		// only use search result if unambiguous
+		if len(mem) == 1 {
+			ent.userID = mem[0].User.ID
+		} else {
+			// don't go crazy with sanitisation, but don't allow callers to pollute with unexpected line breaks
+			ent.name = strings.ReplaceAll(v, "\n", "")
+		}
+	}
+
+	season = -1
+	if v := data[modalKeySeason]; v != "" {
+		u, err := strconv.ParseUint(v, 10, 32)
+		if err != nil {
+			return ent, 0, fmt.Errorf("invalid season value")
+		}
+		season = int(u)
+	}
+
+	if ent.userID != i.Member.User.ID {
+		ent.reporterID = i.Member.User.ID
+	}
+	ent.timestamp = int(time.Now().Unix())
+
+	return ent, season, nil
+}

--- a/leaderboard/modal.go
+++ b/leaderboard/modal.go
@@ -12,6 +12,13 @@ import (
 	"github.com/bwmarrin/discordgo"
 )
 
+const (
+	modalKeyRank       = "rank"
+	modalKeyRankPoints = "rank_points"
+	modalKeyPlayer     = "player"
+	modalKeySeason     = "season"
+)
+
 func presentModal(s *discordgo.Session, i *discordgo.InteractionCreate) error {
 	_, currentSeason, err := getSeasonThread(s, i.GuildID, i.AppID, -1)
 	if err != nil {
@@ -45,7 +52,7 @@ func presentModal(s *discordgo.Session, i *discordgo.InteractionCreate) error {
 				discordgo.ActionsRow{Components: []discordgo.MessageComponent{
 					discordgo.TextInput{Label: "Player",
 						Style:       discordgo.TextInputShort,
-						Placeholder: "Leave empty if reporting own rank",
+						Placeholder: "Leave empty if reporting your own rank",
 						CustomID:    modalKeyPlayer,
 						MaxLength:   80,
 					},

--- a/leaderboard/rank.go
+++ b/leaderboard/rank.go
@@ -1,0 +1,75 @@
+package leaderboard
+
+import (
+	"fmt"
+	"math"
+	"strconv"
+	"strings"
+
+	"github.com/bwmarrin/discordgo"
+	"golang.org/x/text/language"
+	"golang.org/x/text/message"
+	"golang.org/x/text/number"
+)
+
+type entry struct {
+	userID     string
+	name       string
+	rank       int
+	points     int
+	approx     bool
+	guess      bool
+	reporterID string
+	timestamp  int
+}
+
+func userMention(id string) string {
+	return (&discordgo.User{ID: id}).Mention()
+}
+
+func (r entry) String() string {
+	p := message.NewPrinter(language.English)
+
+	player := r.name
+	if r.userID != "" {
+		player = userMention(r.userID)
+	}
+	pts := "(?)"
+	if r.points > 0 {
+		if r.guess {
+			pts = p.Sprintf("(~%dk?)", number.Decimal(int(math.Round(float64(r.points)/1000.))))
+		} else if r.approx {
+			pts = p.Sprintf("(~%dk)", number.Decimal(int(math.Round(float64(r.points)/1000.))))
+		} else {
+			pts = p.Sprintf("(%d)", number.Decimal(r.points))
+		}
+	}
+	reporter := ""
+	if r.reporterID != "" {
+		reporter = " by " + userMention(r.reporterID)
+	}
+
+	return fmt.Sprintf("%d\\. %s %s — <t:%d:R>%s", r.rank, player, pts, r.timestamp, reporter)
+}
+
+func partialParsing(raw string) (rank int, nameOrID string, isID bool) {
+	i := strings.Index(raw, "\\. ")
+	if i >= 0 {
+		rank, _ = strconv.Atoi(raw[:i])
+		raw = raw[i+3:]
+	}
+
+	i = strings.LastIndex(raw, " (")
+	if i >= 0 {
+		raw = raw[:i]
+	}
+
+	nameOrID = raw
+	raw = strings.TrimSuffix(strings.TrimPrefix(raw, "<@"), ">")
+	if _, err := strconv.Atoi(raw); err == nil {
+		nameOrID = raw
+		isID = true
+	}
+
+	return rank, nameOrID, isID
+}

--- a/leaderboard/rank.go
+++ b/leaderboard/rank.go
@@ -6,7 +6,6 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/bwmarrin/discordgo"
 	"golang.org/x/text/language"
 	"golang.org/x/text/message"
 	"golang.org/x/text/number"
@@ -21,10 +20,6 @@ type entry struct {
 	guess      bool
 	reporterID string
 	timestamp  int
-}
-
-func userMention(id string) string {
-	return (&discordgo.User{ID: id}).Mention()
 }
 
 func (r entry) String() string {

--- a/leaderboard/rank.go
+++ b/leaderboard/rank.go
@@ -36,10 +36,11 @@ func (r entry) String() string {
 	}
 	pts := "(?)"
 	if r.points > 0 {
+		rounded := int(math.Round(float64(r.points) / 1000.))
 		if r.guess {
-			pts = p.Sprintf("(~%dk?)", number.Decimal(int(math.Round(float64(r.points)/1000.))))
+			pts = p.Sprintf("(~%dk?)", number.Decimal(rounded))
 		} else if r.approx {
-			pts = p.Sprintf("(~%dk)", number.Decimal(int(math.Round(float64(r.points)/1000.))))
+			pts = p.Sprintf("(~%dk)", number.Decimal(rounded))
 		} else {
 			pts = p.Sprintf("(%d)", number.Decimal(r.points))
 		}
@@ -52,11 +53,12 @@ func (r entry) String() string {
 	return fmt.Sprintf("%d\\. %s %s — <t:%d:R>%s", r.rank, player, pts, r.timestamp, reporter)
 }
 
-func partialParsing(raw string) (rank int, nameOrID string, isID bool) {
+func getRankAndName(raw string) (rank int, nameOrID string, isID bool) {
+	sep := "\\. "
 	i := strings.Index(raw, "\\. ")
 	if i >= 0 {
 		rank, _ = strconv.Atoi(raw[:i])
-		raw = raw[i+3:]
+		raw = raw[i+len(sep):]
 	}
 
 	i = strings.LastIndex(raw, " (")

--- a/leaderboard/rank.go
+++ b/leaderboard/rank.go
@@ -28,12 +28,16 @@ func userMention(id string) string {
 }
 
 func (r entry) String() string {
-	p := message.NewPrinter(language.English)
-
 	player := r.name
 	if r.userID != "" {
 		player = userMention(r.userID)
 	}
+
+	if r.rank == 0 {
+		return player
+	}
+
+	p := message.NewPrinter(language.English)
 	pts := "(?)"
 	if r.points > 0 {
 		rounded := int(math.Round(float64(r.points) / 1000.))

--- a/leaderboard/threads.go
+++ b/leaderboard/threads.go
@@ -1,6 +1,7 @@
 package leaderboard
 
 import (
+	"errors"
 	"fmt"
 	"log"
 	"os"
@@ -16,14 +17,20 @@ func init() {
 	}
 }
 
-var leaderboardsForumName = "leaderboards"
+// hmm, should we do partial matching, or somehow guild-specific? for now all a bit moot anyway...
+var leaderboardsForumName = "│leaderboards"
 
-const (
-	threadNamePrefix = "Season "
+const threadNamePrefix = "Season "
 
+func initialMessage(appID string) string {
 	// OK, hardcoded MYM joke right there... But also probably accurate starting point.
-	initialMessage = "1\\. Fnovc2d (???)"
-)
+	msg := `1\. Fnovc2d (???)
+
+Add master rank players to the leaderboard by calling ` + userMention(appID) + `'s ` + "`rank`" + ` command (that can be invoked by simply typing ` + "`/rank`" + ` from anywhere on this server).
+You may optionally report exact (e.g. ` + "`35123`" + `), approximate (e.g. ` + "`~77000`" + `), or guessed (e.g. ` + "`180000?`" + `) rank points.
+If reporting for another Discord member, it isn't necessary to enter their whole name or username as long as it unambiguously identifies them; priority will be given to exact _username_ match.`
+	return msg
+}
 
 func getSeasonThread(s *discordgo.Session, guildID, authorID string, season int) (*discordgo.Channel, int, error) {
 	latestSeason := -1
@@ -58,7 +65,7 @@ func getSeasonThread(s *discordgo.Session, guildID, authorID string, season int)
 	thrs, err := s.ThreadsActive(c.ID)
 	if err != nil {
 		log.Printf("failed to fetch active threads in %v: %v", c.ID, err)
-		return nil, 0, fmt.Errorf("failed to fetch active threads")
+		return nil, 0, errors.New("failed to fetch active threads")
 	}
 	if thr := selectThread(thrs.Threads); thr != nil {
 		return thr, season, nil
@@ -68,7 +75,7 @@ func getSeasonThread(s *discordgo.Session, guildID, authorID string, season int)
 		thrs, err := s.ThreadsArchived(c.ID, nil, 0)
 		if err != nil {
 			log.Printf("failed to fetch archived threads in %v: %v", c.ID, err)
-			return nil, 0, fmt.Errorf("failed to fetch archived threads")
+			return nil, 0, errors.New("failed to fetch archived threads")
 		}
 		if thr := selectThread(thrs.Threads); thr != nil {
 			return thr, season, nil
@@ -82,7 +89,7 @@ func getSeasonThread(s *discordgo.Session, guildID, authorID string, season int)
 		return nil, 0, fmt.Errorf("season %d not tracked", season)
 	}
 	if latest == nil {
-		return nil, 0, fmt.Errorf("failed to find any active leaderboards")
+		return nil, 0, errors.New("failed to find any active leaderboards")
 	}
 
 	return latest, latestSeason, nil
@@ -92,7 +99,7 @@ func getLeaderboardsForum(s *discordgo.Session, guildID string) (*discordgo.Chan
 	chans, err := s.GuildChannels(guildID)
 	if err != nil {
 		log.Printf("failed to enumerate guild %v channels: %v", guildID, err)
-		return nil, fmt.Errorf("failed to enumerate guild channels")
+		return nil, errors.New("failed to enumerate guild channels")
 	}
 
 	for _, c := range chans {
@@ -101,10 +108,10 @@ func getLeaderboardsForum(s *discordgo.Session, guildID string) (*discordgo.Chan
 		}
 	}
 
-	return nil, fmt.Errorf("could not find the leaderboards forum")
+	return nil, errors.New("could not find the leaderboards forum")
 }
 
-func createSeasonThread(s *discordgo.Session, guildID string, name string) error {
+func createSeasonThread(s *discordgo.Session, guildID string, appID string, name string) error {
 	if !strings.HasPrefix(name, threadNamePrefix) {
 		return fmt.Errorf("invalid season name (should start with %q)", threadNamePrefix)
 	}
@@ -116,7 +123,7 @@ func createSeasonThread(s *discordgo.Session, guildID string, name string) error
 		return fmt.Errorf("invalid season number: %w", err)
 	}
 	if i < 0 {
-		return fmt.Errorf("season number should not be negative")
+		return errors.New("season number should not be negative")
 	}
 
 	c, err := getLeaderboardsForum(s, guildID)
@@ -124,6 +131,11 @@ func createSeasonThread(s *discordgo.Session, guildID string, name string) error
 		return err
 	}
 
-	_, err = s.ForumThreadStart(c.ID, name, 0, initialMessage)
-	return err
+	thr, err := s.ForumThreadStart(c.ID, name, 0, initialMessage(appID))
+	if err != nil {
+		return err
+	}
+
+	s.ChannelMessagePin(thr.ID, thr.ID) // try to pin, if permissions allow...
+	return nil
 }

--- a/leaderboard/threads.go
+++ b/leaderboard/threads.go
@@ -1,0 +1,129 @@
+package leaderboard
+
+import (
+	"fmt"
+	"log"
+	"os"
+	"strconv"
+	"strings"
+
+	"github.com/bwmarrin/discordgo"
+)
+
+func init() {
+	if env := os.Getenv("LEADERBOARDS_FORUM_NAME"); env != "" {
+		leaderboardsForumName = env
+	}
+}
+
+var leaderboardsForumName = "leaderboards"
+
+const (
+	threadNamePrefix = "Season "
+
+	// OK, hardcoded MYM joke right there... But also probably accurate starting point.
+	initialMessage = "1\\. Fnovc2d (???)"
+)
+
+func getSeasonThread(s *discordgo.Session, guildID, authorID string, season int) (*discordgo.Channel, int, error) {
+	latestSeason := -1
+	var latest *discordgo.Channel
+	selectThread := func(thrs []*discordgo.Channel) *discordgo.Channel {
+		for _, thr := range thrs {
+			if thr.ThreadMetadata.Locked || thr.OwnerID != authorID {
+				continue
+			}
+			name := strings.TrimPrefix(thr.Name, threadNamePrefix)
+			name = strings.Split(name, " ")[0]
+			i, err := strconv.Atoi(name)
+			if err != nil {
+				continue
+			}
+			if i == season {
+				return thr
+			}
+			if i > latestSeason {
+				latestSeason = i
+				latest = thr
+			}
+		}
+		return nil
+	}
+
+	c, err := getLeaderboardsForum(s, guildID)
+	if err != nil {
+		return nil, 0, err
+	}
+
+	thrs, err := s.ThreadsActive(c.ID)
+	if err != nil {
+		log.Printf("failed to fetch active threads in %v: %v", c.ID, err)
+		return nil, 0, fmt.Errorf("failed to fetch active threads")
+	}
+	if thr := selectThread(thrs.Threads); thr != nil {
+		return thr, season, nil
+	}
+
+	for {
+		thrs, err := s.ThreadsArchived(c.ID, nil, 0)
+		if err != nil {
+			log.Printf("failed to fetch archived threads in %v: %v", c.ID, err)
+			return nil, 0, fmt.Errorf("failed to fetch archived threads")
+		}
+		if thr := selectThread(thrs.Threads); thr != nil {
+			return thr, season, nil
+		}
+		if !thrs.HasMore {
+			break
+		}
+	}
+
+	if season >= 0 && season != latestSeason {
+		return nil, 0, fmt.Errorf("season %d not tracked", season)
+	}
+	if latest == nil {
+		return nil, 0, fmt.Errorf("failed to find any active leaderboards")
+	}
+
+	return latest, latestSeason, nil
+}
+
+func getLeaderboardsForum(s *discordgo.Session, guildID string) (*discordgo.Channel, error) {
+	chans, err := s.GuildChannels(guildID)
+	if err != nil {
+		log.Printf("failed to enumerate guild %v channels: %v", guildID, err)
+		return nil, fmt.Errorf("failed to enumerate guild channels")
+	}
+
+	for _, c := range chans {
+		if c.Type == discordgo.ChannelTypeGuildForum && c.Name == leaderboardsForumName {
+			return c, nil
+		}
+	}
+
+	return nil, fmt.Errorf("could not find the leaderboards forum")
+}
+
+func createSeasonThread(s *discordgo.Session, guildID string, name string) error {
+	if !strings.HasPrefix(name, threadNamePrefix) {
+		return fmt.Errorf("invalid season name (should start with %q)", threadNamePrefix)
+	}
+
+	str := strings.TrimPrefix(name, threadNamePrefix)
+	str = strings.Split(str, " ")[0]
+	i, err := strconv.Atoi(str)
+	if err != nil {
+		return fmt.Errorf("invalid season number: %w", err)
+	}
+	if i < 0 {
+		return fmt.Errorf("season number should not be negative")
+	}
+
+	c, err := getLeaderboardsForum(s, guildID)
+	if err != nil {
+		return err
+	}
+
+	_, err = s.ForumThreadStart(c.ID, name, 0, initialMessage)
+	return err
+}

--- a/main.go
+++ b/main.go
@@ -17,6 +17,7 @@ var (
 	wsMode   = flag.Bool("ws", false, "run in websocket mode instead of listening for incoming webhooks")
 	register = flag.Bool("register", false, "register bot commands with discord; add the -cleanup flag to first remove any old commands")
 	cleanup  = flag.Bool("cleanup", false, "when running with -register, also first remove any previously registered commands")
+	guildID  = flag.String("guild", "", "optionally restrict register/cleanup to a single guild")
 )
 
 func init() {
@@ -51,11 +52,11 @@ func run() error {
 		}
 
 		if *cleanup {
-			if err := cleanupCommands(s, app.ID); err != nil {
+			if err := cleanupCommands(s, app.ID, *guildID); err != nil {
 				return err
 			}
 		}
-		return registerCommands(s, app.ID)
+		return registerCommands(s, app.ID, *guildID)
 	}
 
 	if *wsMode {

--- a/register.go
+++ b/register.go
@@ -6,11 +6,11 @@ import (
 	"github.com/bwmarrin/discordgo"
 )
 
-func registerCommands(s *discordgo.Session, appID string) error {
+func registerCommands(s *discordgo.Session, appID, guildID string) error {
 	log.Println("Registering commands...")
 
 	for c := range commands {
-		cmd, err := s.ApplicationCommandCreate(appID, "", c)
+		cmd, err := s.ApplicationCommandCreate(appID, guildID, c)
 		if err != nil {
 			return err
 		}
@@ -25,16 +25,18 @@ func registerCommands(s *discordgo.Session, appID string) error {
 	return nil
 }
 
-func cleanupCommands(s *discordgo.Session, appID string) error {
+func cleanupCommands(s *discordgo.Session, appID, guildID string) error {
 	log.Println("Cleaning up commands...")
 
-	guilds, err := s.UserGuilds(200, "", "", false)
-	if err != nil {
-		return err
-	}
-	guildIDs := []string{""}
-	for _, g := range guilds {
-		guildIDs = append(guildIDs, g.ID)
+	guildIDs := []string{guildID}
+	if guildID == "" {
+		guilds, err := s.UserGuilds(200, "", "", false)
+		if err != nil {
+			return err
+		}
+		for _, g := range guilds {
+			guildIDs = append(guildIDs, g.ID)
+		}
 	}
 
 	for _, guildID := range guildIDs {


### PR DESCRIPTION
There are some things that could be done differently, but that's the starting point...

1. It has been structured in a way that the command may be invoked from anywhere (instead of requiring the user to do it specifically from within the relevant leaderboard thread). This will only be tractable if there is a specific dedicated forum channel where all the leaderboard posts are, however.
2. The admin commands are for now hardcoded to only respond to me. The better way to do this would be to use the Discord Guild settings to limit access to that command to only admins instead.
3. I've chose to use a modal to let people input data (instead of command arguments): seems like it might be generally easier to use/understand. It's somewhat defensive in terms of user input, but not overly so either (i.e. doesn't try and sanitise names too much, and will try and do automatic server user matching, etc).